### PR TITLE
Ajout de Deplacement Sommet/ Creer Sous Graphe / Selection

### DIFF
--- a/src/GrapheListe.java
+++ b/src/GrapheListe.java
@@ -38,7 +38,18 @@ public class GrapheListe extends Graphe {
 	 */
 	@Override
 	public void addSommet(Sommet s) {
+		int id = 0;
+		boolean change = true;
 		if(s != null){
+			while(change){
+				change=false;
+				for(Sommet se : sommets){
+					if(id==se.getId()) {
+						id++;
+						change=true;
+					}
+				}
+			}
 			sommets.add(s);
 			this.setNbSommets(getNbSommets()+1);
 			sommets.get(getNbSommets()-1).setID(getNbSommets());

--- a/src/Interface.java
+++ b/src/Interface.java
@@ -1,45 +1,33 @@
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseMotionAdapter;
+import java.awt.event.*;
 import java.awt.geom.AffineTransform;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.ListIterator;
 
 public class Interface extends JComponent {
 
-    private static int largeur = 640;
-    private static int hauteur = 480;
-    private ArrayList<Sommet> SommetSelec;
+    private static int largeur = 1000;
+    private static int hauteur = 600;
+    private ArrayList<Sommet> SommetSelec = new ArrayList<Sommet>();
     private Point ptSouris;
-    private Rectangle rectangleSouris;
+    private Rectangle rectangleSouris = new Rectangle();
     private boolean selectionEnCours;
     private MenuPanel control = new MenuPanel();
     private static Graphe graphe;
     private static int rayon_sommet = 15;
     private Sommet sommet_selection;
+    private JFrame f = new JFrame("Graphe");
+    private JComboBox modeMouse;
 
     public static void main(String[] args) throws Exception{
         EventQueue.invokeLater(new Runnable() {
 
             public void run(){
-                JFrame f = new JFrame("Graphe");
-                f.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
                 Interface inter = new Interface();
-                f.add(inter.control,BorderLayout.NORTH);
-                f.add(new
-
-                        JScrollPane(inter),BorderLayout.CENTER);
-                f.setPreferredSize(new
-
-                        Dimension(largeur, hauteur));
-                f.pack();
-                f.setVisible(true);
-
-
                 graphe = new GrapheListe();
                 graphe.addSommet(new Point(50,50));
                 graphe.addSommet(new Point(250,50));
@@ -59,6 +47,13 @@ public class Interface extends JComponent {
     }
 
     public Interface(){
+        f.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        f.add(this.control,BorderLayout.NORTH);
+        f.add(new JScrollPane(this),BorderLayout.CENTER);
+        f.setPreferredSize(new Dimension(largeur, hauteur));
+        f.pack();
+        f.setVisible(true);
+
         this.setOpaque(true);
 
         this.addMouseListener(new GestionSouris());
@@ -86,6 +81,16 @@ public class Interface extends JComponent {
             drawArrow(g, x1, y1, x2, y2);;
         }
 
+        Graphics2D g2 = (Graphics2D) g;
+        g2.setStroke(new BasicStroke(3));
+        for(Sommet s : SommetSelec){
+            g2.setColor(Color.GRAY);
+            g2.drawRect(s.getPoint().x-rayon_sommet, s.getPoint().y-rayon_sommet, rayon_sommet*2, rayon_sommet*2);
+        }
+
+        g.setColor(Color.darkGray);
+        g.drawRect(rectangleSouris.x, rectangleSouris.y, rectangleSouris.width, rectangleSouris.height);
+
     }
 
     void drawArrow(Graphics g1, int x1, int y1, int x2, int y2) {
@@ -107,12 +112,29 @@ public class Interface extends JComponent {
     private class GestionSouris extends MouseAdapter {
         Point depart;
         Point arrive;
+
         @Override
         public void mousePressed(MouseEvent e) {
             depart = e.getPoint();
             ptSouris = e.getPoint();
             if (e.isPopupTrigger()) {
                 showPopup(e);
+            }
+            else if(getSommetFromPoint(ptSouris)!=null){
+                if(modeMouse.getSelectedItem()=="Selection"){
+                    SommetSelec.clear();
+                    SommetSelec.add(getSommetFromPoint(ptSouris));
+                }
+                else if(modeMouse.getSelectedItem()=="Sommet"){
+                    if(SommetSelec.isEmpty()){
+                        SommetSelec.clear();
+                        SommetSelec.add(getSommetFromPoint(ptSouris));
+                    }
+                    if(SommetSelec.size()==1){
+                        SommetSelec.clear();
+                        SommetSelec.add(getSommetFromPoint(ptSouris));
+                    }
+                }
             }
         }
 
@@ -122,11 +144,16 @@ public class Interface extends JComponent {
             if (e.isPopupTrigger()) {
                 showPopup(e);
             }
-            if(getSommetFromPoint(depart) != getSommetFromPoint(arrive)){
-                graphe.addArc(getSommetFromPoint(depart), getSommetFromPoint(arrive));
+            if(modeMouse.getSelectedItem()=="Arcs"){
+                if(getSommetFromPoint(depart) != getSommetFromPoint(arrive)){
+                    graphe.addArc(getSommetFromPoint(depart), getSommetFromPoint(arrive));
+                    repaint();
+                }
             }
-
-            repaint();
+            if(modeMouse.getSelectedItem()=="Selection"){
+                rectangleSouris = new Rectangle();
+                repaint();
+            }
         }
 
         private void showPopup(MouseEvent e) {
@@ -138,21 +165,73 @@ public class Interface extends JComponent {
     private class SelectionViaClic extends MouseMotionAdapter {
         @Override
         public void mouseDragged(MouseEvent e) {
+            Point p = new Point();
+            if(modeMouse.getSelectedItem()=="Sommet"){
+                p.setLocation(e.getX() - ptSouris.x, e.getY() - ptSouris.y);
+                for(Sommet s: SommetSelec){
+                    s.getPoint().x += p.x;
+                    s.getPoint().y += p.y;
+                }
+                ptSouris = e.getPoint();
+                repaint();
+            }
+            if(modeMouse.getSelectedItem()=="Selection"){
+                SommetSelec.clear();
+                rectangleSouris.setBounds(Math.min(ptSouris.x, e.getX()), Math.min(ptSouris.y, e.getY()), Math.abs(ptSouris.x - e.getX()), Math.abs(ptSouris.y - e.getY()));
+                for (Sommet s : graphe.get_liste_de_sommet()) {
+                    if(rectangleSouris.contains(s.getPoint())){
+                        if(!SommetSelec.contains(s)){
+                            SommetSelec.add(s);
+                        }
+                    }
+                }
+                repaint();
+            }
+        }
+    }
+
+    public class ModeMouseComboBox implements ActionListener{
+        public void actionPerformed(ActionEvent e) {
+            if(modeMouse.getSelectedItem()=="Arcs"){
+                SommetSelec.clear();
+                repaint();
+            }
         }
     }
 
     class MenuPanel extends JMenuBar {
         private Action action_dsatur = new dsaturAction("Dsatur");
+        private Action action_dijkstra = new dijkstraAction("Dijkstra");
+        private Action action_bellman_ford = new bellman_fordAction("Bellman Ford");
+        private Action action_ford_fulkerson = new ford_fulkersonAction("Ford Fulkerson");
+        private Action action_kruskall = new kruskallAction("Kruskall");
+        private Action action_welsh_powell = new welsh_powellAction("Welsh Powell");
+        private Action action_kosaraju = new kosarajuAction("Kosaraju");
+        private Action action_tarjan = new tarjanAction("Tarjan");
+
         private Action action_supression_totale = new suppressionTotaleAction("Tout Supprimer");
         private Action action_ouvrir = new ouvrirAction("Charger");
         private Action action_sauvegarder = new sauvegarderAction("Sauvegarder");
         private Action action_creerSommet = new creerSommetAction("Creer Sommet");
         private Action action_supprimerSommet = new supprimerSommetAction("Supprimer");
+        private Action action_ModifierVariable = new modifierVariableAction("Modifier Variable");
+        private Action action_CreerSousGraphe = new creerSousGrapheAction("Creer Sous Graphe");
+
         private JButton dsatur = new JButton(action_dsatur);
+        private JButton dijkstra = new JButton(action_dijkstra);
+        private JButton bellman_ford = new JButton(action_bellman_ford);
+        private JButton ford_fulkerson = new JButton(action_ford_fulkerson);
+        private JButton kruskall = new JButton(action_kruskall);
+        private JButton welsh_powell = new JButton(action_welsh_powell);
+        private JButton kosaraju = new JButton(action_kosaraju);
+        private JButton tarjan = new JButton(action_tarjan);
+
+
+
         private JButton suppression_totale = new JButton(action_supression_totale);
         private JButton ouvrir = new JButton(action_ouvrir);
         private JButton sauvegarder = new JButton(action_sauvegarder);
-        private JComboBox kindCombo = new JComboBox();
+        private JButton sousGraphe = new JButton(action_CreerSousGraphe);
         private JPopupMenu popup = new JPopupMenu();
 
 
@@ -164,9 +243,17 @@ public class Interface extends JComponent {
             this.add(suppression_totale);
             this.add(ouvrir);
             this.add(sauvegarder);
+            this.add(sousGraphe);
 
             this.popup.add(new JMenuItem(action_creerSommet));
             this.popup.add(new JMenuItem(action_supprimerSommet));
+            this.popup.add(new JMenuItem(action_ModifierVariable));
+
+            this.add(new JLabel("Mode d'édition"));
+            String[] modeMouseString = { "Selection", "Arcs", "Sommet"};
+            modeMouse = new JComboBox(modeMouseString);
+            this.add(modeMouse);
+            modeMouse.addActionListener(new ModeMouseComboBox());
         }
 
     }
@@ -186,8 +273,12 @@ public class Interface extends JComponent {
         public supprimerSommetAction(String name){super(name);}
 
         public void actionPerformed(ActionEvent e){
-            if(getSommetFromPoint(ptSouris)!=null){
-                graphe.deleteSommet(getSommetFromPoint(ptSouris).getId());
+            Sommet s = getSommetFromPoint(ptSouris);
+            if(s!=null){
+                if(SommetSelec.contains(s)){
+                    SommetSelec.remove(s);
+                }
+                graphe.deleteSommet(s.getId());
                 repaint();
             }
         }
@@ -204,6 +295,87 @@ public class Interface extends JComponent {
         }
     }
 
+    class dijkstraAction extends AbstractAction{
+        public dijkstraAction(String name) {
+            super(name);
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            repaint();
+        }
+    }
+
+    class bellman_fordAction extends AbstractAction{
+        public bellman_fordAction(String name) {
+            super(name);
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            repaint();
+        }
+    }
+
+    class ford_fulkersonAction extends AbstractAction{
+        public ford_fulkersonAction(String name) {
+            super(name);
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            repaint();
+        }
+    }
+
+    class kruskallAction extends AbstractAction{
+        public kruskallAction(String name) {
+            super(name);
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            repaint();
+        }
+    }
+
+    class welsh_powellAction extends AbstractAction{
+        public welsh_powellAction(String name) {
+            super(name);
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            repaint();
+        }
+    }
+
+    class kosarajuAction extends AbstractAction{
+        public kosarajuAction(String name) {
+            super(name);
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            repaint();
+        }
+    }
+
+    class tarjanAction extends AbstractAction{
+        public tarjanAction(String name) {
+            super(name);
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            repaint();
+        }
+    }
+
+    class modifierVariableAction extends AbstractAction{
+        public modifierVariableAction(String name) {
+            super(name);
+        }
+
+        public void actionPerformed(ActionEvent e) {
+            /* TODO */
+            repaint();
+        }
+    }
+
     class suppressionTotaleAction extends AbstractAction{
         public suppressionTotaleAction(String name){
             super(name);
@@ -214,6 +386,7 @@ public class Interface extends JComponent {
             graphe.get_liste_arc().clear();
             graphe.setNbSommets(0);
             graphe.setNbArcs(0);
+            SommetSelec.clear();
             repaint();
         }
     }
@@ -249,6 +422,32 @@ public class Interface extends JComponent {
             if(returnVal == JFileChooser.APPROVE_OPTION) {
                 File file = new File(chooser.getSelectedFile() + ".graphe");
                 graphe.sauvegarder(file);
+                repaint();
+            }
+        }
+    }
+
+    class creerSousGrapheAction extends AbstractAction{
+        public creerSousGrapheAction(String name) {
+            super(name);
+        }
+        public void actionPerformed(ActionEvent e) {
+            if(!SommetSelec.isEmpty()){
+                ListIterator<Sommet> i = graphe.get_liste_de_sommet().listIterator();
+                while (i.hasNext()) {
+                    Sommet s = i.next();
+                    if(!SommetSelec.contains(s)){
+                        i.remove();
+                    }
+                }
+                ListIterator<Arc> j = graphe.get_liste_arc().listIterator();
+                while (j.hasNext()) {
+                    Arc a = j.next();
+                    if(!SommetSelec.contains(a.getSommetDepart()) || !SommetSelec.contains(a.getSommetArrivee())){
+                        j.remove();
+                    }
+                }
+                SommetSelec.clear();
                 repaint();
             }
         }


### PR DESCRIPTION
Liste des Modifications:
-Les IDs des sommets sont désormais corrects lorsque l'on créer un nouveau sommet après en avoir supprimer un.
-Réorganisation du constructeur de l'interface pour permettre plus de liberté.
-Ajout de la coloration des sommets selectionnés et du cadre de selection dans paintCompoment.
-Ajout du bouton Creer Sous Graphe pour créer un sous graphe à partir des sommets selectionnés.


-Nouveau dans le menu:
     Mode: "Selection": Permet de selectionner des sommets en cliquant ou en tracant un rectangle de selection. TODO: Maj clic pour selectionner des sommets
      Mode: "Sommet": Permet de déplacer les sommets. Si aucun ou 1 seul selectionné: clic et drag sur un sommet pour le déplacer. Si plusieurs déja selectionnés: clic et drag n'importe ou.
      Mode: "Arc": Permet de tracer les arcs entre les sommets comme avant.
TODO: VOIR AVEC VOUS POUR RENDRE CA PEUT ETRE PLUS ERGONOMIQUE.

-Ajout des Boutons et Actions associés à tout les algos pour les futures implémentations.
